### PR TITLE
MG-147 - Helm Docs Generation Fails with `README.md has changed` error

### DIFF
--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -28,3 +28,6 @@ jobs:
           template-files: "README.md.gotmpl"
           git-push: false
           fail-on-diff: true
+
+      - name: Show README diff
+        run: git diff charts/magistrala/README.md

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -20,6 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate Helm Docs
+        id: helm-docs
         uses: losisin/helm-docs-github-action@v1.3.1
         with:
           chart-search-root: "charts/magistrala"
@@ -30,4 +31,7 @@ jobs:
           fail-on-diff: true
 
       - name: Show README diff
-        run: git diff charts/magistrala/README.md
+        if: failure()  # Run only if the Helm Docs generation step fails
+        run: |
+          echo "README.md changes detected. Showing diff:"
+          git diff charts/magistrala/README.md || echo "No git diff available."

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -14,10 +14,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}
-          fetch-depth: 0
 
       - name: Generate Helm Docs
         id: helm-docs
@@ -31,7 +27,5 @@ jobs:
           fail-on-diff: true
 
       - name: Show README diff
-        if: failure()  # Run only if the Helm Docs generation step fails
-        run: |
-          echo "README.md changes detected. Showing diff:"
-          git diff charts/magistrala/README.md || echo "No git diff available."
+        if: failure() && steps.helm-docs.outcome == 'failure'
+        run: git diff charts/magistrala/README.md || echo "No git diff available."

--- a/.github/workflows/helm-docs.yaml
+++ b/.github/workflows/helm-docs.yaml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.ref }}
+          fetch-depth: 0
 
       - name: Generate Helm Docs
         id: helm-docs


### PR DESCRIPTION
### **What does this do?**

This PR adds a step to show a `git diff` of `README.md` if the Helm Docs generation fails due to differences (with `fail-on-diff` set to true). This helps to diagnose what exactly changed in the README.md during the documentation generation.

### **Which issue(s) does this PR fix/relate to?**

- Resolves #147 

### **List any changes that modify/break current functionality**

No existing functionality is broken.

### **Have you included tests for your changes?**

No

### **Did you document any new/modified functionality?**

No

### **Notes**

This will help to troubleshoot and address failures due to unexpected changes in the `README.md` during the Helm Docs generation process, giving more insight into what exactly is causing CI failure.
