### PR TITLE
NOISSUE - Align chart releases with Magistrala versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Call Common Steps
-        uses: ./.github/workflows/common.yaml
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
@@ -41,19 +43,7 @@ jobs:
         run: |
           helm dependency update charts/magistrala
 
-      - name: Add Dependencies
-        run: |
-          helm repo add stable https://charts.helm.sh/stable
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
-          helm repo add hashicorp https://helm.releases.hashicorp.com
-          helm repo add nats https://nats-io.github.io/k8s/helm/charts/
-          helm repo update
-        
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
-        with:
-          charts_dir: charts/magistrala
-          config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.HELM_RELEASE_TOKEN }}"

--- a/charts/magistrala/Chart.yaml
+++ b/charts/magistrala/Chart.yaml
@@ -6,8 +6,8 @@ name: magistrala
 description: Magistrala IoT Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 1.0.6        # Incremented chart version if the chart is updated
-appVersion: "0.14.0"  # Update application version if the app is updated
+version: 0.14.0 # Incremented chart version if the chart is updated
+appVersion: "0.14.0" # Update application version if the app is updated
 home: https://abstractmachines.fr/magistrala.html
 sources:
   - https://hub.docker.com/u/magistrala
@@ -49,7 +49,6 @@ dependencies:
     repository: "@bitnami"
     alias: postgresqlusers
     condition: postgresqlusers.enabled
-
 
   - name: postgresql
     version: "12.5.6"


### PR DESCRIPTION
### What does this do?
This pull request updates the Helm chart for Magistrala to align the chart version (version: 0.14.0) with the application version (appVersion: 0.14.0). This ensures that the chart release and the application version stay in sync, making it easier to manage releases.

### Which issue(s) does this PR fix/relate to?
None

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
