### PR TITLE
NOISSUE - replace specific versions with `latest` tag

### DIFF
--- a/charts/magistrala/Chart.yaml
+++ b/charts/magistrala/Chart.yaml
@@ -6,8 +6,8 @@ name: magistrala
 description: Magistrala IoT Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: "latest" # The chart version should ideally be aligned with the app version, but for now we are using 'latest' for convenience.
-appVersion: "latest" # The application version. This should be updated when the app is modified.
+version: "o.14.0" # The chart version should ideally be aligned with the app version, but for now we are using 'latest' for convenience.
+appVersion: "0.14.0" # The application version. This should be updated when the app is modified.
 home: https://abstractmachines.fr/magistrala.html
 sources:
   - https://hub.docker.com/u/magistrala

--- a/charts/magistrala/Chart.yaml
+++ b/charts/magistrala/Chart.yaml
@@ -6,8 +6,8 @@ name: magistrala
 description: Magistrala IoT Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 0.14.0 # Incremented chart version if the chart is updated
-appVersion: "0.14.0" # Update application version if the app is updated
+version: "latest" # The chart version should ideally be aligned with the app version, but for now we are using 'latest' for convenience.
+appVersion: "latest" # The application version. This should be updated when the app is modified.
 home: https://abstractmachines.fr/magistrala.html
 sources:
   - https://hub.docker.com/u/magistrala

--- a/charts/magistrala/README.md
+++ b/charts/magistrala/README.md
@@ -2,7 +2,7 @@
 
 Magistrala IoT Platform
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
 
 **Homepage:** <https://abstractmachines.fr/magistrala.html>
 

--- a/charts/magistrala/README.md
+++ b/charts/magistrala/README.md
@@ -2,7 +2,7 @@
 
 Magistrala IoT Platform
 
-![Version: latest](https://img.shields.io/badge/Version-latest-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: latest](https://img.shields.io/badge/AppVersion-latest-informational?style=flat-square)
+![Version: o.14.0](https://img.shields.io/badge/Version-o.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
 
 **Homepage:** <https://abstractmachines.fr/magistrala.html>
 


### PR DESCRIPTION
### What does this do?

This PR replaces the specific versions in the `charts/magistrala/Chart.yaml` file with the tag `latest` for both the chart version and app version. 

### Which issue(s) does this PR fix/relate to?

None

### List any changes that modify/break current functionality

None

### Have you included tests for your changes?

No

### Did you document any new/modified functionality?

No

### Notes

- The use of `latest` for both chart version and app version is temporary and will be revisited when versioning policies are updated.