### PR TITLE
MG-141 - Bootstrap and Certs service are not starting properly in k8s setup with HELM

### DIFF
--- a/charts/magistrala/Chart.yaml
+++ b/charts/magistrala/Chart.yaml
@@ -13,7 +13,7 @@ sources:
   - https://hub.docker.com/u/magistrala
 maintainers:
   - name: drasko
-    email: draasko.draskovic@abstractmachines.fr
+    email: drasko.draskovic@abstractmachines.fr
   - name: dusan
     email: dusan.borovcanin@abstractmachines.fr
 

--- a/charts/magistrala/README.md
+++ b/charts/magistrala/README.md
@@ -10,7 +10,7 @@ Magistrala IoT Platform
 
 | Name | Email | Url |
 | ---- | ------ | --- |
-| drasko | <draasko.draskovic@abstractmachines.fr> |  |
+| drasko | <drasko.draskovic@abstractmachines.fr> |  |
 | dusan | <dusan.borovcanin@abstractmachines.fr> |  |
 
 ## Source Code
@@ -60,26 +60,32 @@ Magistrala IoT Platform
 | bootstrap.encKey | string | `"randomstring"` |  |
 | bootstrap.eventConsumerName | string | `"EventConsumerByBootstrap"` |  |
 | bootstrap.httpPort | int | `9013` |  |
-| bootstrap.image | object | `{}` |  |
+| bootstrap.image.pullPolicy | string | `"IfNotPresent"` |  |
+| bootstrap.image.pullSecrets | object | `{}` |  |
+| bootstrap.image.repository | string | `"magistrala/bootstrap"` |  |
+| bootstrap.image.tag | string | `"latest"` |  |
+| bootstrap.jaegerTraceRatio | float | `1` |  |
+| bootstrap.logLevel | string | `"info"` |  |
 | bootstrap.redisESPort | int | `6379` |  |
-| certs.enabled | bool | `false` |  |
+| bootstrap.sendTelemetry | bool | `true` |  |
+| certs.enabled | bool | `true` |  |
 | certs.httpPort | int | `9019` |  |
 | certs.image | object | `{}` |  |
 | certs.logLevel | string | `"info"` |  |
 | certs.signCAKeyPath | string | `"/etc/ssl/certs/ca.key"` |  |
 | certs.signCAPath | string | `"/etc/ssl/certs/ca.crt"` |  |
-| certs.vault.approleRoleid | string | `""` |  |
-| certs.vault.approleSecret | string | `""` |  |
-| certs.vault.namespace | string | `""` |  |
-| certs.vault.thingsCertsPkiPath | string | `""` |  |
-| certs.vault.thingsCertsPkiRoleName | string | `""` |  |
-| certs.vault.url | string | `""` |  |
+| certs.vault.approleRoleid | string | `"magistrala"` |  |
+| certs.vault.approleSecret | string | `"magistrala"` |  |
+| certs.vault.namespace | string | `"magistrala"` |  |
+| certs.vault.thingsCertsPkiPath | string | `"pki_int"` |  |
+| certs.vault.thingsCertsPkiRoleName | string | `"magistrala_things_certs"` |  |
+| certs.vault.url | string | `"http://magistrala-vault:8200"` |  |
 | defaults.eventStreamURL | string | `"magistrala-nats:4222"` |  |
 | defaults.image.pullPolicy | string | `"IfNotPresent"` |  |
 | defaults.image.rootRepository | string | `"magistrala"` |  |
 | defaults.image.tag | string | `"latest"` |  |
 | defaults.jaegerCollectorPort | int | `4318` |  |
-| defaults.jaegerTraceRatio | int | `10` |  |
+| defaults.jaegerTraceRatio | float | `1` |  |
 | defaults.logLevel | string | `"info"` |  |
 | defaults.natsPort | int | `4222` |  |
 | defaults.replicaCount | int | `3` |  |
@@ -308,4 +314,4 @@ Magistrala IoT Platform
 | users.passwordRegex | string | `"^.{8,}$"` |  |
 | users.secretKey | string | `"secretKey"` |  |
 | users.tokenResetEndpoint | string | `"/reset-request"` |  |
-| vault.enabled | bool | `false` |  |
+| vault.enabled | bool | `true` |  |

--- a/charts/magistrala/templates/bootstrap-deployment.yaml
+++ b/charts/magistrala/templates/bootstrap-deployment.yaml
@@ -42,11 +42,17 @@ spec:
               value: {{ .Values.defaults.eventStreamURL | quote }}
             - name: MG_BOOTSTRAP_LOG_LEVEL
               value: {{ default .Values.defaults.logLevel .Values.bootstrap.logLevel | quote }}
-            - name: MG_BOOTSTRAP_HOST
+            - name: MG_BOOTSTRAP_HTTP_HOST
               value: "0.0.0.0"
-            - name: MG_BOOTSTRAP_PORT
+            - name: MG_BOOTSTRAP_HTTP_PORT
               value: {{ .Values.bootstrap.httpPort | quote }}
             - name: MG_THINGS_URL
+              value: http://{{ .Release.Name }}-things:{{ .Values.things.httpPort }}
+            - name: MG_THINGS_ES_URL              
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.things.redisESPort }}
+            - name: MG_BOOTSTRAP_ES_URL
+              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.bootstrap.redisESPort }}
+            - name: MG_SDK_BASE_URL              
               value: http://{{ .Release.Name }}-things:{{ .Values.things.httpPort }}
             - name: MG_AUTH_GRPC_URL
               value: {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
@@ -66,7 +72,7 @@ spec:
               value: {{ .Values.postgresqlbootstrap.username | quote }}
             - name: MG_BOOTSTRAP_DB_PASS
               value: {{ .Values.postgresqlbootstrap.password | quote }}
-            - name: MG_BOOTSTRAP_NAME
+            - name: MG_BOOTSTRAP_DB_NAME
               value: {{ .Values.postgresqlbootstrap.database | quote }}
 
           ports:

--- a/charts/magistrala/templates/bootstrap-deployment.yaml
+++ b/charts/magistrala/templates/bootstrap-deployment.yaml
@@ -50,10 +50,6 @@ spec:
               value: http://{{ .Release.Name }}-things:{{ .Values.things.httpPort }}
             - name: MG_THINGS_ES_URL              
               value: {{ .Release.Name }}-redis-streams-master:{{ .Values.things.redisESPort }}
-            - name: MG_BOOTSTRAP_ES_URL
-              value: {{ .Release.Name }}-redis-streams-master:{{ .Values.bootstrap.redisESPort }}
-            - name: MG_SDK_BASE_URL              
-              value: http://{{ .Release.Name }}-things:{{ .Values.things.httpPort }}
             - name: MG_AUTH_GRPC_URL
               value: {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
             - name: MG_BOOTSTRAP_ENCRYPT_KEY

--- a/charts/magistrala/templates/journal-deployment.yaml
+++ b/charts/magistrala/templates/journal-deployment.yaml
@@ -47,19 +47,19 @@ spec:
               value: {{ .Values.journal.httpPort  | quote  }}
             - name : MG_AUTH_GRPC_URL
               value: {{ .Release.Name }}-envoy:{{ .Values.auth.grpcPort }}
-            - name: MG_JOURNAL_HOST
+            - name: MG_JOURNAL_DB_HOST
             {{- if .Values.postgresqljournal.enabled }}
               value: "{{ .Release.Name }}-postgresqljournal"
             {{- else }}
               value: {{ .Values.postgresqljournal.host | quote }}
             {{- end }}
-            - name: MG_JOURNAL_PORT
+            - name: MG_JOURNAL_DB_PORT
               value: {{ .Values.postgresqljournal.port  | quote }}
-            - name: MG_JOURNAL_NAME
+            - name: MG_JOURNAL_DB_NAME
               value: {{ .Values.postgresqljournal.database | quote }}
-            - name: MG_JOURNAL_USER
+            - name: MG_JOURNAL_DB_USER
               value: {{ .Values.postgresqljournal.username | quote }}
-            - name: MG_JOURNAL_PASS
+            - name: MG_JOURNAL_DB_PASS
               value: {{ .Values.postgresqljournal.password | quote }}
           ports:
             - containerPort: {{ .Values.journal.httpPort }}

--- a/charts/magistrala/templates/things-deployment.yaml
+++ b/charts/magistrala/templates/things-deployment.yaml
@@ -56,7 +56,7 @@ spec:
               value: {{ .Values.postgresqlthings.username | quote }}
             - name: MG_THINGS_DB_PASS
               value: {{ .Values.postgresqlthings.password | quote }}
-            - name: MG_THINGS_DB
+            - name: MG_THINGS_DB_NAME
               value: {{ .Values.postgresqlthings.database | quote }}
             - name: MG_ES_URL
               value: {{ .Values.defaults.eventStreamURL | quote }}

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -414,7 +414,7 @@ certs:
     thingsCertsPkiRoleName: magistrala_things_certs
 
 vault:
-  enabled: true
+  enabled: false
 
 postgresqlcerts:
   ## If you want to use an external database, set this to false and change host & port to external postgresql server host & port respectively

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -406,12 +406,12 @@ certs:
   signCAPath: "/etc/ssl/certs/ca.crt"
   signCAKeyPath: "/etc/ssl/certs/ca.key"
   vault:
-    url: ""
-    approleRoleid: ""
-    approleSecret: ""
-    namespace: ""
-    thingsCertsPkiPath: ""
-    thingsCertsPkiRoleName: ""
+    url: "http://magistrala-vault:8200"
+    approleRoleid: magistrala
+    approleSecret: magistrala
+    namespace: magistrala
+    thingsCertsPkiPath: pki_int
+    thingsCertsPkiRoleName: magistrala_things_certs
 
 vault:
   enabled: true

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -360,10 +360,10 @@ bootstrap:
     pullSecrets: {}
     repository: "magistrala/bootstrap"
     tag: "latest"
-    pullPolicy: "Always"
+    pullPolicy: "IfNotPresent"
   jaegerTraceRatio: 10
   sendTelemetry: true
-  logLevel: "debug"
+  logLevel: "info"
   httpPort: 9013
   redisESPort: 6379
   encKey: "randomstring"

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -10,8 +10,7 @@ defaults:
     pullPolicy: "IfNotPresent"
     rootRepository: "magistrala"
     tag: "latest"
-    # pullSecrets:
-    #   - {}
+    # pullSecrets: {}
   # Replicas of MQTT adapter, NATS, Things, Envoy and Auth
   replicaCount: 3
   natsPort: 4222
@@ -356,15 +355,15 @@ redis-things:
   usePassword: false
 
 bootstrap:
-  image: {}
-    # pullSecrets: {}
-    # repository: "magistrala/bootstrap"
-    # tag: "latest"
-    # pullPolicy: "IfNotPresent"
-  # jaegerTraceRatio: 10
-  # sendTelemetry: true
-  # logLevel: "info"
   enabled: true
+  image:
+    pullSecrets: {}
+    repository: "magistrala/bootstrap"
+    tag: "latest"
+    pullPolicy: "Always"
+  jaegerTraceRatio: 10
+  sendTelemetry: true
+  logLevel: "debug"
   httpPort: 9013
   redisESPort: 6379
   encKey: "randomstring"
@@ -567,7 +566,7 @@ ui:
     # repository: "magistrala/ui"
     # tag: "latest"
     # pullPolicy: "IfNotPresent"
-  # logLevel: "info"
+    # logLevel: "info"
   # hostname: ""
   # contentTypes: "application/senml+json"
   port: 9095
@@ -582,7 +581,6 @@ ui:
   # invitationsUrl: "http:///magistrala-auth:9020"
   # journalUrl: "http:///magistrala-auth:9021"
   # domainsUrl: "http://magistrala-auth:8189"
-  # bootstrapUrl: "http://magistrala-boostrap:9013"
   googleClientID: ""
   googleClientSecret: ""
   googleRedirectHostname: "https://stage-domain-name"

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -15,7 +15,7 @@ defaults:
   replicaCount: 3
   natsPort: 4222
   jaegerCollectorPort: 4318
-  jaegerTraceRatio: 10
+  jaegerTraceRatio: 1.0
   sendTelemetry: true
   eventStreamURL: "magistrala-nats:4222"
 
@@ -234,7 +234,7 @@ auth:
     # tag: "latest"
     # pullPolicy: "IfNotPresent"
   # Log level for the auth service. Common options are "debug", "info", "warn", "error".
-  # jaegerTraceRatio: 10
+  # jaegerTraceRatio: 1.0
   # sendTelemetry: true
   httpPort: 8189
   grpcPort: 8181
@@ -274,7 +274,7 @@ users:
      # repository: "magistrala/users"
      # tag: "latest"
      # pullPolicy: "IfNotPresent"
-  # jaegerTraceRatio: 10
+  # jaegerTraceRatio: 1.0
   # sendTelemetry: true
   # logLevel: "info"
   httpPort: 9002
@@ -361,7 +361,7 @@ bootstrap:
     repository: "magistrala/bootstrap"
     tag: "latest"
     pullPolicy: "IfNotPresent"
-  jaegerTraceRatio: 10
+  jaegerTraceRatio: 1.0
   sendTelemetry: true
   logLevel: "info"
   httpPort: 9013
@@ -399,7 +399,7 @@ certs:
     # repository: "magistrala/certs"
     # tag: "latest"
     # pullPolicy: "IfNotPresent"
-  # jaegerTraceRatio: 10
+  # jaegerTraceRatio: 1.0
   # sendTelemetry: true
   httpPort: 9019
   logLevel: "info"
@@ -443,7 +443,7 @@ invitations:
     # repository: "magistrala/invitations"
     # tag: "latest"
     # pullPolicy: "IfNotPresent"
-  # jaegerTraceRatio: 10
+  # jaegerTraceRatio: 1.0
   # sendTelemetry: true
   # logLevel: "info"
   httpPort: 9020
@@ -478,7 +478,7 @@ journal:
     # repository: "magistrala/journal"
     # tag: "latest"
     # pullPolicy: "IfNotPresent"
-  # jaegerTraceRatio: 10
+  # jaegerTraceRatio: 1.0
   # sendTelemetry: true
   # logLevel: "info"
   httpPort: 9021
@@ -521,7 +521,7 @@ timescaledb:
       # repository: "magistrala/timescale-reader"
       # tag: "latest"
       # pullPolicy: "IfNotPresent"
-    # jaegerTraceRatio: 10
+    # jaegerTraceRatio: 1.0
     # sendTelemetry: true
     # logLevel: "info"
     enabled: true
@@ -535,7 +535,7 @@ timescaledb:
       # repository: "magistrala/timescale-writer"
       # tag: "latest"
       # pullPolicy: "IfNotPresent"
-    # jaegerTraceRatio: 10
+    # jaegerTraceRatio: 1.0
     # sendTelemetry: true
     # logLevel: "info"
     # nodeSelector: {}

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -393,7 +393,7 @@ postgresqlbootstrap:
           postgresql: *postgresqlBootstrapPort
 
 certs:
-  enabled: false
+  enabled: true
   image: {}
     # pullSecrets: {}
     # repository: "magistrala/certs"
@@ -414,7 +414,7 @@ certs:
     thingsCertsPkiRoleName: ""
 
 vault:
-  enabled: false
+  enabled: true
 
 postgresqlcerts:
   ## If you want to use an external database, set this to false and change host & port to external postgresql server host & port respectively

--- a/scripts/vault/vault.md
+++ b/scripts/vault/vault.md
@@ -1,6 +1,7 @@
 ## How to Install and Configure `vault` with `certs`
 
 ### Prerequisites:
+
 1. **Kubernetes Configuration**: Ensure your `KUBECONFIG` is set up to point to the Kubernetes cluster where you want to deploy `vault`. This can typically be done by running:
    ```bash
    export KUBECONFIG=/path/to/your/kubeconfig
@@ -10,6 +11,7 @@
 ### Step 1: Install `vault` using Helm
 
 1. **Navigate to the `magistrala` Helm chart directory**:
+
    ```bash
    cd charts/magistrala
    ```
@@ -18,13 +20,22 @@
    ```bash
    helm upgrade magistrala . -n mg --set vault.enabled=true
    ```
-This command uses Helm to upgrade (or install) the `magistrala` release in the `mg` namespace with `vault` enabled.
+   This command uses Helm to upgrade (or install) the `magistrala` release in the `mg` namespace with `vault` enabled.
 
 ### Step 2: Initialize `vault`
 
-1. **Navigate to the `vault` scripts directory**:
+1. **Navigate to the `vault` Scripts Directory**:
+
+   If you are currently in the `charts/magistrala` directory, go up two levels to the root and then to the `vault` scripts directory by running:
+
    ```bash
    cd ../../scripts/vault
+   ```
+
+   If you are at the root of the repository, navigate to the `vault` scripts directory directly by running:
+
+   ```bash
+   cd scripts/vault
    ```
 
 2. **Run the `vault_init.sh` script**:
@@ -36,12 +47,15 @@ This command uses Helm to upgrade (or install) the `magistrala` release in the `
 ### Step 3: Enable the `certs` Service and Apply Configuration
 
 1. **Load Environment Variables**:
+
    ```bash
    source .env
    ```
-    This command loads environment variables from the `.env` file into your current shell session. These variables are required for the next step to configure the `certs` service.
+
+   This command loads environment variables from the `.env` file into your current shell session. These variables are required for the next step to configure the `certs` service.
 
 2. **Navigate back to the `magistrala` Helm chart directory**:
+
    ```bash
    cd ../../charts/magistrala
    ```
@@ -52,5 +66,5 @@ This command uses Helm to upgrade (or install) the `magistrala` release in the `
        --set certs.vault.url=$MG_VAULT_ADDR \
        --set certs.vault.approleRoleid=$MG_VAULT_THINGS_CERTS_ISSUER_ROLEID \
        --set certs.vault.approleSecret=$MG_VAULT_THINGS_CERTS_ISSUER_SECRET \
-       --set certs.vault.namespace=$MG_VAULT_NAMESPACE 
+       --set certs.vault.namespace=$MG_VAULT_NAMESPACE
    ```

--- a/scripts/vault/vault.md
+++ b/scripts/vault/vault.md
@@ -1,27 +1,56 @@
-# Install and configure `vault` with `certs`
-Make sure you configured your `KUBECONFIG` to point to destination cluster.
+## How to Install and Configure `vault` with `certs`
 
-Install vault
+### Prerequisites:
+1. **Kubernetes Configuration**: Ensure your `KUBECONFIG` is set up to point to the Kubernetes cluster where you want to deploy `vault`. This can typically be done by running:
+   ```bash
+   export KUBECONFIG=/path/to/your/kubeconfig
+   ```
+   This command tells your local machine which Kubernetes cluster to interact with.
 
-```bash
-cd charts/magistrala
-helm upgrade magistrala . -n mg  --set vault.enabled=true
-```
+### Step 1: Install `vault` using Helm
 
-Initialize vault
-```bash
-cd ../../scripts/vault
-./vault_init.sh
-```
+1. **Navigate to the `magistrala` Helm chart directory**:
+   ```bash
+   cd charts/magistrala
+   ```
 
+2. **Install `vault`**:
+   ```bash
+   helm upgrade magistrala . -n mg --set vault.enabled=true
+   ```
+This command uses Helm to upgrade (or install) the `magistrala` release in the `mg` namespace with `vault` enabled.
 
-Now upgrade installation of magistrala enabling certs service and setting proper values
-```bash
-source .env
-cd ../../charts/magistrala
-helm upgrade magistrala  --create-namespace -n mg . \
-                    --set certs.vault.url=$MG_VAULT_ADDR \
-                    --set certs.vault.approleRoleid=$MG_VAULT_THINGS_CERTS_ISSUER_ROLEID \
-                    --set certs.vault.approleSecret=$MG_VAULT_THINGS_CERTS_ISSUER_SECRET \
-                    --set certs.vault.namespace=$MG_VAULT_NAMESPACE 
-```
+### Step 2: Initialize `vault`
+
+1. **Navigate to the `vault` scripts directory**:
+   ```bash
+   cd ../../scripts/vault
+   ```
+
+2. **Run the `vault_init.sh` script**:
+   ```bash
+   ./vault_init.sh
+   ```
+   This script initializes `vault` by setting up necessary configurations, such as unsealing the vault and applying initial policies. This is a crucial step to get `vault` ready for use.
+
+### Step 3: Enable the `certs` Service and Apply Configuration
+
+1. **Load Environment Variables**:
+   ```bash
+   source .env
+   ```
+    This command loads environment variables from the `.env` file into your current shell session. These variables are required for the next step to configure the `certs` service.
+
+2. **Navigate back to the `magistrala` Helm chart directory**:
+   ```bash
+   cd ../../charts/magistrala
+   ```
+
+3. **Upgrade the `magistrala` installation with `certs` enabled**:
+   ```bash
+   helm upgrade magistrala --create-namespace -n mg . \
+       --set certs.vault.url=$MG_VAULT_ADDR \
+       --set certs.vault.approleRoleid=$MG_VAULT_THINGS_CERTS_ISSUER_ROLEID \
+       --set certs.vault.approleSecret=$MG_VAULT_THINGS_CERTS_ISSUER_SECRET \
+       --set certs.vault.namespace=$MG_VAULT_NAMESPACE 
+   ```

--- a/scripts/vault/vault_create_approle.sh
+++ b/scripts/vault/vault_create_approle.sh
@@ -7,30 +7,65 @@ set -euo pipefail
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $scriptdir
+echo "Script directory set to: $scriptdir"
 
 SKIP_ENABLE_APP_ROLE=${1:-}
 
 readDotEnv() {
     set -o allexport
+    echo "Sourcing environment variables from .env file..."
     source $scriptdir/.env
     set +o allexport
+}
+
+# Check if a service is running in the Kubernetes cluster
+is_service_running() {
+    local service_name="$1"
+    local namespace="${2:-default}"  # Default namespace is 'default' if not specified
+
+    echo "Checking if service $service_name is running in namespace $namespace..."
+    if kubectl get svc -n "$namespace" | grep -q "^$service_name"; then
+        echo "Service $service_name is running."
+        return 0
+    else
+        echo "Service $service_name is not running or not found in the namespace $namespace."
+        return 1
+    fi
 }
 
 source vault_cmd.sh
 
 vaultCreatePolicyFile() {
+    echo "Creating policy file from template..."
     envsubst '
     ${MG_VAULT_PKI_INT_PATH}
     ${MG_VAULT_PKI_INT_THINGS_CERTS_ROLE_NAME}
-    ' <  magistrala_things_certs_issue.template.hcl >  magistrala_things_certs_issue.hcl
+    ' < magistrala_things_certs_issue.template.hcl > magistrala_things_certs_issue.hcl
+
+    if [ -f magistrala_things_certs_issue.hcl ]; then
+        echo "Policy file magistrala_things_certs_issue.hcl created successfully."
+    else
+        echo "Failed to create policy file magistrala_things_certs_issue.hcl."
+        exit 1
+    fi
 }
+
 vaultCreatePolicy() {
     echo "Creating new policy for AppRole"
-    if is_container_running "magistrala-vault"; then
-        docker cp magistrala_things_certs_issue.hcl magistrala-vault:/vault/magistrala_things_certs_issue.hcl
-        vault policy write -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} magistrala_things_certs_issue /vault/magistrala_things_certs_issue.hcl
+    if is_service_running "magistrala-vault" "mg"; then
+        echo "Proceeding with policy creation..."
+        
+        echo "Copying policy file to the pod..."
+        kubectl cp magistrala_things_certs_issue.hcl mg/magistrala-vault-0:/tmp/magistrala_things_certs_issue.hcl
+        
+        echo "Policy file copied to pod. Now attempting to create policy in Vault..."
+        
+        # Run the policy creation inside the pod
+        kubectl exec magistrala-vault-0 -n mg -- vault policy write -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} magistrala_things_certs_issue /tmp/magistrala_things_certs_issue.hcl
+        
     else
-        vault policy write -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} magistrala_things_certs_issue magistrala_things_certs_issue.hcl
+        echo "Service magistrala-vault is not running or not found in the mg namespace."
+        exit 1
     fi
 }
 
@@ -44,7 +79,7 @@ vaultEnableAppRole() {
 }
 
 vaultDeleteRole() {
-    echo "Deleteing old AppRole"
+    echo "Deleting old AppRole"
     vault delete -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} auth/approle/role/magistrala_things_certs_issuer
 }
 
@@ -77,15 +112,21 @@ vaultTestRoleLogin() {
 if ! command -v jq &> /dev/null
 then
     echo "jq command could not be found, please install it and try again."
-    exit
+    exit 1
 fi
 
+echo "Reading environment variables..."
 readDotEnv
 
-vault login  -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} ${MG_VAULT_TOKEN}
+echo "Logging into Vault..."
+vault login -namespace=${MG_VAULT_NAMESPACE} -address=${MG_VAULT_ADDR} ${MG_VAULT_TOKEN}
 
+echo "Creating policy file..."
 vaultCreatePolicyFile
+
+echo "Creating policy in Vault..."
 vaultCreatePolicy
+
 vaultEnableAppRole
 vaultDeleteRole
 vaultCreateRole


### PR DESCRIPTION
### What does this do?
This pull fixes helm charts to make sure Bootstrap and Certs services start correctly when deploying Magistrala using Helm in a Kubernetes environment. 

### Which issue(s) does this PR fix/relate to?
- Resolves #141 

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
