### PR TITLE
NOISSUE - Fix invalid chart directory in `lint-test.yaml`

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs charts/magistrala/charts
+          ct lint --chart-dirs charts --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/magistrala/Chart.yaml
+++ b/charts/magistrala/Chart.yaml
@@ -6,8 +6,8 @@ name: magistrala
 description: Magistrala IoT Platform
 icon: https://avatars1.githubusercontent.com/u/13207490
 type: application
-version: 0.14.1 # Incremented chart version if the chart is updated
-appVersion: "0.14.0" # Update application version if the app is updated
+version: 0.14.2  # Incremented chart version if the chart is updated
+appVersion: "0.14.0"  # Update application version if the app is updated
 home: https://abstractmachines.fr/magistrala.html
 sources:
   - https://hub.docker.com/u/magistrala

--- a/charts/magistrala/README.md
+++ b/charts/magistrala/README.md
@@ -2,7 +2,7 @@
 
 Magistrala IoT Platform
 
-![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 0.14.2](https://img.shields.io/badge/Version-0.14.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
 
 **Homepage:** <https://abstractmachines.fr/magistrala.html>
 
@@ -95,25 +95,16 @@ Magistrala IoT Platform
 | invitations.image | object | `{}` |  |
 | jaeger.agent.enabled | bool | `false` |  |
 | jaeger.allInOne.enabled | bool | `false` |  |
-| jaeger.cassandra.config.cluster_name | string | `"jaeger"` |  |
-| jaeger.cassandra.config.dc_name | string | `"dc1"` |  |
-| jaeger.cassandra.config.endpoint_snitch | string | `"GossipingPropertyFileSnitch"` |  |
-| jaeger.cassandra.config.rack_name | string | `"rack1"` |  |
-| jaeger.cassandra.config.seed_size | int | `1` |  |
 | jaeger.cassandra.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | jaeger.cassandra.persistence.enabled | bool | `true` |  |
 | jaeger.cassandra.persistence.size | string | `"10Gi"` |  |
 | jaeger.cassandra.persistence.storageClass | string | `"do-block-storage"` |  |
+| jaeger.collector.service.otlp.grpc.name | string | `"otlp-grpc"` |  |
+| jaeger.collector.service.otlp.grpc.port | int | `4317` |  |
+| jaeger.collector.service.otlp.http.name | string | `"otlp-http"` |  |
+| jaeger.collector.service.otlp.http.port | int | `4318` |  |
 | jaeger.fullnameOverride | string | `"magistrala-jaeger"` |  |
 | jaeger.provisionDataStore.cassandra | bool | `true` |  |
-| jaeger.storage.cassandra.host | string | `"magistrala-cassandra.mg.svc.cluster.local"` |  |
-| jaeger.storage.cassandra.keyspace | string | `"jaeger_v1"` |  |
-| jaeger.storage.cassandra.password | string | `"cassandra_password"` |  |
-| jaeger.storage.cassandra.port | int | `9042` |  |
-| jaeger.storage.cassandra.schemaJobEnabled | bool | `true` |  |
-| jaeger.storage.cassandra.tls.enabled | bool | `false` |  |
-| jaeger.storage.cassandra.usePassword | bool | `true` |  |
-| jaeger.storage.cassandra.user | string | `"cassandra_user"` |  |
 | jaeger.storage.type | string | `"cassandra"` |  |
 | journal.enabled | bool | `true` |  |
 | journal.httpPort | int | `9021` |  |

--- a/charts/magistrala/values.yaml
+++ b/charts/magistrala/values.yaml
@@ -542,7 +542,7 @@ timescaledb:
     # sendTelemetry: true
     # logLevel: "info"
     enabled: true
-    http: { port: 9011 }
+    http: {port: 9011}
     # nodeSelector: {}
     # affinity: {}
     # tolerations: {}
@@ -560,7 +560,7 @@ timescaledb:
     # affinity: {}
     # tolerations: {}
     enabled: true
-    http: { port: 9012 }
+    http: {port: 9012}
   ## Configurations of Bitnami postgres
   global:
     postgresql:


### PR DESCRIPTION
### What does this do?

This pull request fixes the issue where the provided chart directory was not being detected as a valid Helm chart directory during the `ct lint` step in the GitHub CI workflow.

### Which issue(s) does this PR fix/relate to?
None

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?
No

### Notes
This is the received logs from the CI
```bash
Run ct lint --target-branch main --chart-dirs charts/magistrala/
Linting charts...
>>> helm version --template {{ .Version }}
>>> git rev-parse --is-inside-work-tree
>>> git rev-parse --verify origin/main
>>> git merge-base origin/main HEAD
>>> git diff --find-renames --name-only 277fe28b0343dafe56e8be88a69f5c8eec649e[18](https://github.com/absmach/magistrala/actions/runs/11127502755/job/30919951217?pr=103#step:9:19) -- charts/magistrala/
Directory "charts/magistrala" is not a valid chart directory. Skipping...
Directory "charts/magistrala" is not a valid chart directory. Skipping...
Directory "charts/magistrala" is not a valid chart directory. Skipping...
Directory "charts/magistrala" is not a valid chart directory. Skipping...
Directory "charts/magistrala" is not a valid chart directory. Skipping...
Directory "charts/magistrala/charts" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala/templates" is not a valid chart directory. Skipping...
Directory "charts/magistrala" is not a valid chart directory. Skipping...

------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

This is the expected logs from the CI
```bash
Run ct lint --chart-dirs charts --target-branch main
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 magistrala => (version: "0.14.1", path: "charts/magistrala")
------------------------------------------------------------------------------------------------------------------------

Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "magistrala-devops" chart repository
...Successfully got an update from the "nats" chart repository
...Successfully got an update from the "hashicorp" chart repository
...Successfully got an update from the "jaegertracing" chart repository
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Downloading magistrala from repo https://absmach.github.io/devops/
Deleting outdated charts
Could not verify charts/magistrala/charts/.gitignore for deletion: file 'charts/magistrala/charts/.gitignore' does not appear to be a gzipped archive; got 'application/octet-stream' (Skipping)
Linting chart "magistrala => (version: \"1.0.0\", path: \"charts/magistrala\")"
Checking chart "magistrala => (version: \"1.0.0\", path: \"charts/magistrala\")" for a version bump...
Unable to find chart on main. New chart detected.
Validating /home/runner/work/magistrala/magistrala/charts/magistrala/Chart.yaml...
Validation success! 👍
Validating maintainers...
==> Linting charts/magistrala

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ magistrala => (version: "1.0.0", path: "charts/magistrala")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
